### PR TITLE
Minor updates to setup instructions

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -36,6 +36,7 @@ In your preferred web browser:
       - Click Save URLs
     - Under Scopes and **Bot Token Scopes**, 
         - Add `commands` so we can add a shortcut and a slash command
+        - Add `users:read` so that we can lookup the user that executes commands
 
 5. If you plan to install your application to more than one workspace, go to **Manage Distribution** and activate public distribution
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -29,8 +29,13 @@ In your preferred web browser:
       - For the Callback ID, it is important you set it to `shortcuts_phrase_search`
     - Enter your Select Menus Options Load URL `https://your-host/slack/events`
 
+3. Go to **Slash Commands**
+    - Create New Command
+    - Command: /define
+    - Request URL: `https://your-host/slack/events`
+    - Short Description: Search for phrases
 
-3. Go to **OAuth & Permissions** to add a bot scope
+4. Go to **OAuth & Permissions** to add a bot scope
     - Under **Redirect URLs**
       - Add `https://your-host/app_installed`
       - Click Save URLs


### PR DESCRIPTION
###  Summary

The Slack app needs to request the `users:read` scope in order to use the `users.info` method.
The instructions for creating a slash command were not originally included but the app does allow this functionality.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing guidelines](../CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
